### PR TITLE
Trim version handler class name

### DIFF
--- a/magnolia-module-thymeleaf-blossom-renderer/src/main/resources/META-INF/magnolia/thymeleaf-blossom-renderer.xml
+++ b/magnolia-module-thymeleaf-blossom-renderer/src/main/resources/META-INF/magnolia/thymeleaf-blossom-renderer.xml
@@ -4,8 +4,7 @@
 	<name>thymeleaf-blossom-renderer</name>
 	<displayName>Thymeleaf Blossom Renderer</displayName>
 	<class>org.sevensource.magnolia.thymeleaf.blossom.MagnoliaThymeleafBlossomRendererModule</class>
-	<versionHandler>org.sevensource.magnolia.thymeleaf.blossom.setup.MagnoliaThymeleafBlossomRendererVersionHandler
-	</versionHandler>
+	<versionHandler>org.sevensource.magnolia.thymeleaf.blossom.setup.MagnoliaThymeleafBlossomRendererVersionHandler</versionHandler>
 	<version>${project.version}</version>
 
 	<dependencies>


### PR DESCRIPTION
Class loader can't find class "org.sevensource.magnolia.thymeleaf.blossom.setup.MagnoliaThymeleafBlossomRendererVersionHandler\n\t"
Please note superfluous "\n\t" at the end.